### PR TITLE
open files in utf-8

### DIFF
--- a/fontawesome_6/utils.py
+++ b/fontawesome_6/utils.py
@@ -19,7 +19,7 @@ def get_icon_choices():
         'light': 'fal',
     }
 
-    with open(os.path.join(os.path.dirname(__file__), path)) as f:
+    with open(os.path.join(os.path.dirname(__file__), path), encoding="utf-8") as f:
         icons = json.load(f)
 
     for icon in icons:


### PR DESCRIPTION
By not passing along an encoding-parameter to the open command, we rely on the default encoding being able to read the incoming files, which is not always the case for systems that have ASCII as their standard encoding. By specifying utf-8, we're on the safer side.
(Encoding problems occurred e.g. when starting docker containers made from debian images that tried to import the django-fontawesome-6 package, and the container couldn't start up in production-mode.)